### PR TITLE
Enable SSL on restconf driver

### DIFF
--- a/src/main/resources/config/application.yml
+++ b/src/main/resources/config/application.yml
@@ -29,7 +29,13 @@ spring:
 
 server:
   port: 8196
+    key-store-type: PKCS12
+    key-store: /var/lm/keystore/keystore.p12
+    key-store-password: password
+    key-alias: restconf-driver
+    enabled: true
 
+    
 #logging:
 #  level:
 #    root: ERROR

--- a/src/main/resources/config/application.yml
+++ b/src/main/resources/config/application.yml
@@ -29,13 +29,14 @@ spring:
 
 server:
   port: 8196
+  ssl:
     key-store-type: PKCS12
     key-store: /var/lm/keystore/keystore.p12
     key-store-password: password
     key-alias: restconf-driver
     enabled: true
 
-    
+
 #logging:
 #  level:
 #    root: ERROR

--- a/src/main/resources/docker/commands.sh
+++ b/src/main/resources/docker/commands.sh
@@ -1,5 +1,12 @@
 #!/bin/bash
 
+KEYSTOREDIR=/var/lm/keystore
+KEYSTORE=$KEYSTOREDIR/keystore.p12
+CERTDIR=/var/restconfdriver/certs
+CERTKEY=$CERTDIR/tls.key
+CERT=$CERTDIR/tls.crt
+
+
 cd ${alm_restconf_directory}
-openssl pkcs12 -export -inkey /var/restconfdriver/certs/tls.key -in /var/restconfdriver/certs/tls.crt -out /var/lm/keystore/keystore.p12 -password pass:password -name "restconf-driver"
+openssl pkcs12 -export -inkey $CERTKEY -in $CERT -out $KEYSTORE -password pass:password -name "restconf-driver"
 java $JVM_OPTIONS -jar /data/restconf-driver-@project.version@.jar

--- a/src/main/resources/docker/commands.sh
+++ b/src/main/resources/docker/commands.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
 
 cd ${alm_restconf_directory}
+openssl pkcs12 -export -inkey /var/restconfdriver/certs/tls.key -in /var/restconfdriver/certs/tls.crt -out /var/lm/keystore/keystore.p12 -password pass:password -name "restconf-driver"
 java $JVM_OPTIONS -jar /data/restconf-driver-@project.version@.jar

--- a/src/main/resources/helm/restconf-driver/templates/_helpers
+++ b/src/main/resources/helm/restconf-driver/templates/_helpers
@@ -1,0 +1,8 @@
+{{/*
+Generate SSL certificate
+*/}}
+{{- define "gen-cert" -}}
+{{- $cert := genSelfSignedCert "restconf-driver" nil nil 3650 -}}
+tls.crt: {{ $cert.Cert | b64enc }}
+tls.key: {{ $cert.Key | b64enc }}
+{{- end -}}

--- a/src/main/resources/helm/restconf-driver/templates/restconf-driver.yaml
+++ b/src/main/resources/helm/restconf-driver/templates/restconf-driver.yaml
@@ -103,7 +103,7 @@ spec:
             httpGet:
               path: /management/health
               port: 8196
-              scheme: HTTP
+              scheme: HTTPS
             initialDelaySeconds: {{ .Values.app.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.app.livenessProbe.periodSeconds }}
           readinessProbe:
@@ -111,7 +111,7 @@ spec:
             httpGet:
               path: /management/health
               port: 8196
-              scheme: HTTP
+              scheme: HTTPS
             initialDelaySeconds: {{ .Values.app.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.app.readinessProbe.periodSeconds }}
           envFrom:

--- a/src/main/resources/helm/restconf-driver/templates/restconf-driver.yaml
+++ b/src/main/resources/helm/restconf-driver/templates/restconf-driver.yaml
@@ -120,12 +120,23 @@ spec:
           resources:
 {{ toYaml .Values.app.resources | indent 12 }}
 {{- if .Values.app.certificateSecret }}
-          volumeMounts:
-            - mountPath: /var/lm/certs
-              name: certificates
+          - mountPath: /var/lm/certs
+            name: certificates
+{{- end }}
+          - name: {{ .Values.app.config.security.ssl.secret.name }}
+            mountPath: /var/restconfdriver/certs
+          - name: {{ .Values.global.security.certificates.keystore.secretName }}
+            mountPath: /var/lm/keystore
       volumes:
+{{- if .Values.app.certificateSecret }}
       - name: certificates
         secret:
           defaultMode: 420
           secretName: {{ .Values.app.certificateSecret }}
 {{- end }}
+      - name: {{ .Values.app.config.security.ssl.secret.name }}
+        secret:
+          secretName: {{ .Values.app.config.security.ssl.secret.name }}
+
+      - name: {{ .Values.global.security.certificates.keystore.secretName }}
+        emptyDir: {}

--- a/src/main/resources/helm/restconf-driver/templates/restconf-driver.yaml
+++ b/src/main/resources/helm/restconf-driver/templates/restconf-driver.yaml
@@ -119,6 +119,7 @@ spec:
               name: restconf-driver
           resources:
 {{ toYaml .Values.app.resources | indent 12 }}
+          volumeMounts:
 {{- if .Values.app.certificateSecret }}
           - mountPath: /var/lm/certs
             name: certificates
@@ -137,6 +138,5 @@ spec:
       - name: {{ .Values.app.config.security.ssl.secret.name }}
         secret:
           secretName: {{ .Values.app.config.security.ssl.secret.name }}
-
       - name: {{ .Values.global.security.certificates.keystore.secretName }}
         emptyDir: {}

--- a/src/main/resources/helm/restconf-driver/templates/tls-secret.yaml
+++ b/src/main/resources/helm/restconf-driver/templates/tls-secret.yaml
@@ -1,0 +1,12 @@
+{{- if and .Values.app.config.security.ssl.enabled .Values.app.config.security.ssl.secret.generate }}
+apiVersion: v1
+kind: Secret
+type: kubernetes.io/tls
+metadata:
+  name: {{ .Values.app.config.security.ssl.secret.name }}
+  labels:
+    app: restconf-driver
+    release: {{ .Release.Name }}
+data:
+{{ ( include "gen-cert" . ) | indent 2 }}
+{{- end }}

--- a/src/main/resources/helm/restconf-driver/values.yaml
+++ b/src/main/resources/helm/restconf-driver/values.yaml
@@ -21,6 +21,9 @@ global:
   ## Enable the use of LM security features
   security:
     enabled: false
+    certificates:
+      keystore:
+        secretName: lm-keystore
 ## Docker
 docker:
   ## Name of the Docker Image
@@ -47,6 +50,13 @@ app:
     ## Environment Options
     ## Add environment variables to the pods
     # env:
+    security:
+      ssl:
+        enabled: True
+        secret:
+          generate: True
+          name: restconf-driver-tls
+          commonName: restconf-driver
   ## secret containing client certificates that are to be trusted
   certificateSecret:
   ## Probe configuration for checking Application availability


### PR DESCRIPTION
- [x] Issue: Enable SSL on restconf driver #50 
- [x] List of related PRs.
- [x] Project builds without any errors.
- [x] Unit Tests updated (or created where needed) and all pass.
- [x] You have ran manual functional “smoke” test (does product as a whole still work?).
- [x] User Story meets the acceptance criteria - and passes. acceptance criteria should be understood at outset.
- [x]  **Description of the changes**: restconf Resource Driver must be installed with SSL enabled by default. 

Signed-off-by: haynesdavis