### PR TITLE
fix unit test fail when ssl is enabled

### DIFF
--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -14,3 +14,12 @@ spring:
   jackson:
     serialization:
       indent_output: true
+
+server:
+  port: 8196
+  ssl:
+    key-store-type: PKCS12
+    key-store: /var/lm/keystore/keystore.p12
+    key-store-password: password
+    key-alias: restconf-driver
+    enabled: false


### PR DESCRIPTION
#56 
Unit test fails when ssl is enabled. Configure application-test.yml to disable ssl.