### PR TITLE
Use Keystore password from the secret cp4na-o-keystore

### DIFF
--- a/src/main/resources/docker/commands.sh
+++ b/src/main/resources/docker/commands.sh
@@ -16,5 +16,5 @@ CERTKEY=$CERTDIR/tls.key
 CERT=$CERTDIR/tls.crt
 
 cd ${alm_restconf_directory}
-openssl pkcs12 -export -inkey $CERTKEY -in $CERT -out $KEYSTORE -password pass:password -name "restconf-driver"
+! -f $KEYSTORE ] && openssl pkcs12 -export -inkey $CERTKEY -in $CERT -out $KEYSTORE -password pass:"${SERVER_SSL_KEY_STORE_PASSWORD}" -name "restconf-driver"
 java $JVM_OPTIONS -jar /data/restconf-driver-@project.version@.jar

--- a/src/main/resources/helm/restconf-driver/templates/restconf-driver.yaml
+++ b/src/main/resources/helm/restconf-driver/templates/restconf-driver.yaml
@@ -119,6 +119,12 @@ spec:
               name: restconf-driver
           resources:
 {{ toYaml .Values.app.resources | indent 12 }}
+          env:
+           - name: SERVER_SSL_KEY_STORE_PASSWORD
+             valueFrom:
+               secretKeyRef:
+                 name: {{ .Values.global.security.certificates.keystore.secretName }}
+                 key: keystorePassword
           volumeMounts:
 {{- if .Values.app.certificateSecret }}
           - mountPath: /var/lm/certs

--- a/src/main/resources/helm/restconf-driver/values.yaml
+++ b/src/main/resources/helm/restconf-driver/values.yaml
@@ -23,7 +23,7 @@ global:
     enabled: false
     certificates:
       keystore:
-        secretName: lm-keystore
+        secretName: cp4na-o-keystore
 ## Docker
 docker:
   ## Name of the Docker Image


### PR DESCRIPTION
#62 
Keystore password used in enabling ssl needs to be obtained from the secret cp4na-o-keystore.
Signed-off-by: Haynes Davis <haynes.davis@ibm.com>