### PR TITLE
Java17 update and dependency updates - Issue/118

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <!-- Must be duplicated for versions:set plugin to work in builds -->
     <groupId>com.ibm.restconf</groupId>
     <artifactId>restconf-driver</artifactId>
-    <version>0.1.5-SNAPSHOT</version>
+    <version>0.1.5-java17</version>
     <packaging>jar</packaging>
 
     <name>restconf</name>
@@ -36,8 +36,9 @@
         <helm.repo.api.url>${helm.repo.addr}/api/accanto</helm.repo.api.url>
         <helm.repo.snapshots.url>${helm.repo.addr}/accanto/snapshots</helm.repo.snapshots.url>
         <helm.repo.url>${helm.repo.addr}/accanto/stable</helm.repo.url>
-        <jacoco-maven-plugin.version>0.8.4</jacoco-maven-plugin.version>
-        <java.version>11</java.version>
+        <jacoco-maven-plugin.version>0.8.8</jacoco-maven-plugin.version>
+        <java.version>17</java.version>
+	<nashorn-core.version>15.4</nashorn-core.versio
         <kiwigrid.version>4.13</kiwigrid.version>
         <logstash-logback-encoder.version>7.2</logstash-logback-encoder.version>
         <maven-eclipse-plugin.version>2.10</maven-eclipse-plugin.version>
@@ -82,6 +83,11 @@
             <artifactId>logstash-logback-encoder</artifactId>
             <version>${logstash-logback-encoder.version}</version>
         </dependency>
+	<dependency>
+             <groupId>org.openjdk.nashorn</groupId>
+             <artifactId>nashorn-core</artifactId>
+             <version>${nashorn-core.version}</version>
+         </dependency>
         <dependency>
             <groupId>org.jsoup</groupId>
             <artifactId>jsoup</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <!-- Must be duplicated for versions:set plugin to work in builds -->
     <groupId>com.ibm.restconf</groupId>
     <artifactId>restconf-driver</artifactId>
-    <version>0.1.5-java17</version>
+    <version>0.1.5-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>restconf</name>
@@ -38,13 +38,13 @@
         <helm.repo.url>${helm.repo.addr}/accanto/stable</helm.repo.url>
         <jacoco-maven-plugin.version>0.8.8</jacoco-maven-plugin.version>
         <java.version>17</java.version>
-	<nashorn-core.version>15.4</nashorn-core.version>
         <kiwigrid.version>4.13</kiwigrid.version>
         <logstash-logback-encoder.version>7.2</logstash-logback-encoder.version>
         <maven-eclipse-plugin.version>2.10</maven-eclipse-plugin.version>
         <maven.build.timestamp.format>yyyyMMddHHmmss</maven.build.timestamp.format>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
+        <nashorn-core.version>15.4</nashorn-core.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <project.testresult.directory>${project.build.directory}/test-results</project.testresult.directory>
@@ -83,15 +83,15 @@
             <artifactId>logstash-logback-encoder</artifactId>
             <version>${logstash-logback-encoder.version}</version>
         </dependency>
-	<dependency>
-             <groupId>org.openjdk.nashorn</groupId>
-             <artifactId>nashorn-core</artifactId>
-             <version>${nashorn-core.version}</version>
-         </dependency>
         <dependency>
             <groupId>org.jsoup</groupId>
             <artifactId>jsoup</artifactId>
             <version>1.15.3</version>
+        </dependency>
+        <dependency>
+            <groupId>org.openjdk.nashorn</groupId>
+            <artifactId>nashorn-core</artifactId>
+            <version>${nashorn-core.version}</version>
         </dependency>
         <dependency>
             <groupId>org.projectlombok</groupId>
@@ -151,16 +151,16 @@
             <artifactId>spring-kafka-test</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.springframework.security</groupId>
-            <artifactId>spring-security-test</artifactId>
-            <scope>test</scope>
-        </dependency>
-        
+
         <dependency>
             <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-core</artifactId>
             <version>5.7.5</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-test</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.yaml</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
         <helm.repo.url>${helm.repo.addr}/accanto/stable</helm.repo.url>
         <jacoco-maven-plugin.version>0.8.8</jacoco-maven-plugin.version>
         <java.version>17</java.version>
-	<nashorn-core.version>15.4</nashorn-core.versio
+	<nashorn-core.version>15.4</nashorn-core.version>
         <kiwigrid.version>4.13</kiwigrid.version>
         <logstash-logback-encoder.version>7.2</logstash-logback-encoder.version>
         <maven-eclipse-plugin.version>2.10</maven-eclipse-plugin.version>

--- a/src/main/resources/docker/Dockerfile
+++ b/src/main/resources/docker/Dockerfile
@@ -1,5 +1,5 @@
 ARG JDK_IMAGE=icr.io/appcafe/ibm-semeru-runtimes
-ARG JDK_VERSION=certified-11-jre-ubi
+ARG JDK_VERSION=certified-17-jre-ubi
 FROM ${JDK_IMAGE}:${JDK_VERSION}
 ENV JVM_OPTIONS=-Xmx256m
 COPY *.sh /data/


### PR DESCRIPTION
# Pull Request Review

## Checklist

- [x] **Issue** : https://github.com/IBM/restconf-driver/issues/118
- [x] **List of related PRs** : N.A.
- [x] **Project builds without any errors** Yes
- [x] **Unit Tests** : All passed
- [x] **Ran manual functional “smoke” test (does product as a whole still work?)** Yes
- [x] **User Story meets the acceptance criteria and passes** Yes
- [x]  **Description of the changes**:  
1. Updated pom.xml to use Java17. 
2. Updated Dockerfile to use java17 image 
3. Added open source nashorn dependency in pom.xml as it is removed from Java15 onwards
4. Updated dependent library version of Jacobo and Spotify's docker-maven-plugin versions.