### PR TITLE
replaced null with empty string for all message and contenttype fields

### DIFF
--- a/src/main/java/com/ibm/restconf/driver/CiscoCncServiceDriver.java
+++ b/src/main/java/com/ibm/restconf/driver/CiscoCncServiceDriver.java
@@ -142,7 +142,7 @@ public class CiscoCncServiceDriver {
         headers.setAccept(List.of(MediaType.APPLICATION_JSON));
         final HttpEntity<String> requestEntity = new HttpEntity<>(headers);
         UUID uuid = UUID.randomUUID();
-        LoggingUtils.logEnabledMDC(null, MessageType.REQUEST, MessageDirection.SENT, uuid.toString(),null, "http",
+        LoggingUtils.logEnabledMDC("", MessageType.REQUEST, MessageDirection.SENT, uuid.toString(),"", "http",
                 RequestResponseLogUtils.getRequestSentProtocolMetaData(url, "POST", headers), driverRequestId);
         final ResponseEntity<JWTToken> responseEntity;
         try {
@@ -252,7 +252,7 @@ public class CiscoCncServiceDriver {
             throw e;
         }
 
-        LoggingUtils.logEnabledMDC(null, MessageType.RESPONSE,MessageDirection.RECEIVED,uuid.toString(), null, "http",
+        LoggingUtils.logEnabledMDC("", MessageType.RESPONSE,MessageDirection.RECEIVED,uuid.toString(), "", "http",
                 RequestResponseLogUtils.getResponseReceivedProtocolMetaData(responseEntity.getStatusCodeValue(), responseEntity.getStatusCode().getReasonPhrase(), responseEntity.getHeaders()),driverRequestId);
         checkResponseEntityMatches(responseEntity, HttpStatus.CREATED, false);
     }
@@ -298,7 +298,7 @@ public class CiscoCncServiceDriver {
                     RequestResponseLogUtils.getResponseReceivedProtocolMetaData(HttpStatus.INTERNAL_SERVER_ERROR.value(), HttpStatus.INTERNAL_SERVER_ERROR.getReasonPhrase(), null), driverRequestId);
             throw e;
         }
-        LoggingUtils.logEnabledMDC(null,MessageType.RESPONSE,MessageDirection.RECEIVED,uuid.toString(), null, "http",
+        LoggingUtils.logEnabledMDC("",MessageType.RESPONSE,MessageDirection.RECEIVED,uuid.toString(), "", "http",
                 RequestResponseLogUtils.getResponseReceivedProtocolMetaData(responseEntity.getStatusCodeValue(), responseEntity.getStatusCode().getReasonPhrase(), responseEntity.getHeaders()), driverRequestId);
         checkResponseEntityMatches(responseEntity, HttpStatus.NO_CONTENT, false);
     }
@@ -331,7 +331,7 @@ public class CiscoCncServiceDriver {
         final HttpEntity<String> requestEntity = new HttpEntity<>(payload, headers);
 
         UUID uuid = UUID.randomUUID();
-        LoggingUtils.logEnabledMDC(null, MessageType.REQUEST,MessageDirection.SENT, uuid.toString(),null, "http",
+        LoggingUtils.logEnabledMDC("", MessageType.REQUEST,MessageDirection.SENT, uuid.toString(),"", "http",
                 RequestResponseLogUtils.getRequestSentProtocolMetaData(url, "DELETE", headers), driverRequestId);
         final ResponseEntity<String> responseEntity;
         try {
@@ -343,7 +343,7 @@ public class CiscoCncServiceDriver {
             throw e;
         }
 
-        LoggingUtils.logEnabledMDC(null, MessageType.RESPONSE,MessageDirection.RECEIVED,uuid.toString(),null, "http",
+        LoggingUtils.logEnabledMDC("", MessageType.RESPONSE,MessageDirection.RECEIVED,uuid.toString(),"", "http",
                 RequestResponseLogUtils.getResponseReceivedProtocolMetaData(responseEntity.getStatusCodeValue(), responseEntity.getStatusCode().getReasonPhrase(), responseEntity.getHeaders()), driverRequestId);
         checkResponseEntityMatches(responseEntity, HttpStatus.NO_CONTENT, false);
     }


### PR DESCRIPTION
# Pull Request Review

## Checklist

- [x] **Issue** : https://github.com/IBM/restconf-driver/issues/124
- [x] **List of related PRs** : N.A.
- [x] **Project builds without any errors** Yes
- [x] **Unit Tests** : All passed
- [x] **Ran manual functional “smoke” test (does product as a whole still work?)** No
- [x] **User Story meets the acceptance criteria and passes** Yes
- [x]  **Description of the changes**:   Updated all external log message and content type fileds from null to empty string as these are mandatory fields for logging.